### PR TITLE
Add handling of view disappearing and reappearing by resetting layers on viewDidAppear

### DIFF
--- a/DetectorAppSwiftUI/ViewController.swift
+++ b/DetectorAppSwiftUI/ViewController.swift
@@ -30,6 +30,11 @@ class ViewController: UIViewController, AVCaptureVideoDataOutputSampleBufferDele
             self.captureSession.startRunning()
         }
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        // Reset layers when view reappears
+        self.setupLayers()
+    }
     
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         screenRect = UIScreen.main.bounds


### PR DESCRIPTION
When running this sample code as part of a larger codebase, if the ViewController view is suspended by navigating to another part of the app, the sublayers are reset and therefore the bounding boxes are not visible when the ViewController reappears.

In order to handle this, calling self.setupLayers() on viewDidAppear recreates the layers and allows the bounding boxes to be visible.