### PR TITLE
Fix: detection layer to be added in the main thread

### DIFF
--- a/DetectorAppSwiftUI/Detector.swift
+++ b/DetectorAppSwiftUI/Detector.swift
@@ -43,7 +43,9 @@ extension ViewController {
     func setupLayers() {
         detectionLayer = CALayer()
         detectionLayer.frame = CGRect(x: 0, y: 0, width: screenRect.size.width, height: screenRect.size.height)
-        self.view.layer.addSublayer(detectionLayer)
+        DispatchQueue.main.async { [weak self] in 
+            self!.view.layer.addSublayer(self!.detectionLayer)
+        }
     }
     
     func updateLayers() {


### PR DESCRIPTION
Current application have the issue that bounding boxes are not displayed somoothly when the application is lounched.

Reason:
The reason of this issue is that the detection layer is added at other threads insted main thread.

How to fix:
addSublayer function is called at main thread using DispatchQueue.main.async.